### PR TITLE
feat(buttons): add embed interactions

### DIFF
--- a/src/buttons/embeds.ts
+++ b/src/buttons/embeds.ts
@@ -1,0 +1,42 @@
+import { button } from 'jellycommands';
+import { MODERATOR_IDS } from '../config';
+import { get_member, has_any_role_or_id } from '../utils/snowflake';
+import type advise from '../events/on_message/_advise';
+
+/**
+ * Handle interaction responses in {@link advise}.
+ */
+export default button({
+	id: /^embed_\w+$/,
+
+	async run({ interaction }) {
+		const [, action, author_id] = interaction.customId.split('_') as [
+			string,
+			'keep' | 'hide',
+			string,
+		];
+
+		/**
+		 * Interacting user is either the author of the original message
+		 * or a moderator.
+		 */
+		const valid_user = has_any_role_or_id(await get_member(interaction), [
+			author_id,
+			...MODERATOR_IDS,
+		]);
+
+		if (!valid_user) {
+			await interaction.reply({
+				content:
+					'Only the original author or a moderator may interact with this post.',
+				flags: 'Ephemeral',
+			});
+			return;
+		}
+
+		if (action === 'hide') {
+			await interaction.message.suppressEmbeds(true);
+		}
+		await interaction.update({ components: [] });
+	},
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,14 +11,16 @@ export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 // #region people
 const ADMIN_ROLES = [
 	// Moderators role in main server
-	// '919214972557484073',
+	'919214972557484073',
 
 	// // Maintainers role
 	// '571775211431526410',
 
 	// // Admins role
-	// '476141440091815947',
+	'476141440091815947',
+];
 
+const PRIVILEGED_ROLES = [
 	// Threadlords
 	'949258457352114176',
 ];
@@ -29,14 +31,16 @@ const TEST_ADMIN_ROLES = ['918888136581476402'];
 /**
  * List of roles/user IDs allowed to delete tags even if they're not the author.
  */
-export const TAG_DEL_PERMITTED_IDS = DEV_MODE ? TEST_ADMIN_ROLES : ADMIN_ROLES;
+export const TAG_DEL_PERMITTED_IDS = DEV_MODE
+	? TEST_ADMIN_ROLES
+	: PRIVILEGED_ROLES;
 
 /**
  * List of roles/user IDs allowed to create tags.
  */
 export const TAG_CREATE_PERMITTED_IDS = DEV_MODE
 	? TEST_ADMIN_ROLES
-	: ADMIN_ROLES;
+	: PRIVILEGED_ROLES;
 
 export const BOT_DEVS = [
 	// cirilla
@@ -50,8 +54,10 @@ export const BOT_DEVS = [
  */
 export const THREAD_ADMIN_IDS = [
 	...BOT_DEVS,
-	...(DEV_MODE ? TEST_ADMIN_ROLES : ADMIN_ROLES),
+	...(DEV_MODE ? TEST_ADMIN_ROLES : PRIVILEGED_ROLES),
 ];
+
+export const MODERATOR_IDS = DEV_MODE ? TEST_ADMIN_ROLES : ADMIN_ROLES;
 
 // #endregion
 

--- a/src/events/on_message/_advise.ts
+++ b/src/events/on_message/_advise.ts
@@ -1,4 +1,11 @@
-import { type Message } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	MessagePayload,
+	userMention,
+	type Message,
+} from 'discord.js';
 import urlRegex from 'url-regex';
 
 export default async function mutate_content(message: Message) {
@@ -19,12 +26,30 @@ export default async function mutate_content(message: Message) {
 
 	const link_term = updated_link_list.length === 1 ? 'link' : 'links';
 
-	// Reply inline
-	try {
-		await message.reply(
-			`I converted your \`x.com\` ${link_term} to use \`xcancel.com\` so that server members won't require an account to view content and threads:\n${updated_link_list}`,
-		);
+	const content = `${userMention(message.author.id)} I converted your \`x.com\` ${link_term} to use \`xcancel.com\` so that server members won't require an account to view content and threads:\n${updated_link_list}`;
 
+	const hide_button = new ButtonBuilder()
+		.setLabel('Hide embed')
+		.setCustomId(`embed_hide_${message.author.id}`)
+		.setStyle(ButtonStyle.Secondary);
+
+	const keep_button = new ButtonBuilder()
+		.setLabel('Keep embed')
+		.setCustomId(`embed_keep_${message.author.id}`)
+		.setStyle(ButtonStyle.Primary);
+
+	const row = new ActionRowBuilder<ButtonBuilder>({
+		components: [hide_button, keep_button],
+	});
+
+	const payload = new MessagePayload(message.channel, {
+		content,
+		components: [row],
+	});
+
+	// Send message with interactions
+	try {
+		await message.channel.send(payload);
 		await message.suppressEmbeds(true);
 	} catch {
 		// don't handle failures


### PR DESCRIPTION
- When user posts an x.com link, the bot replies with the link converted to use xcancel.com along with button options to hide or keep the embed.
- Either the original author or a moderator may interact with these buttons.

<img width="769" height="697" alt="image" src="https://github.com/user-attachments/assets/da0092e1-cc28-4338-8e91-11dbf92ac335" />
