### PR TITLE
fix(on_message): ensure slow mode is unset after server restart

### DIFF
--- a/src/events/on_message/_slow_mode.ts
+++ b/src/events/on_message/_slow_mode.ts
@@ -140,6 +140,12 @@ export default async function slow_mode(message: Message): Promise<void> {
 		channel_message_queue,
 	);
 
+	// Secret joke
+	// TODO: refactor into its own hook
+	if (message.content.includes('the bot is here')) {
+		await message.react('👀');
+	}
+
 	// Return early if:
 	//
 	// - new level is equal to current level


### PR DESCRIPTION
Closes #59 

- Track slow mode state per unique channel
- When there's a mismatch between server state and actual state, re-assess channel activity
- Refactor some variables to `snake_case`
- Add a little Easter Egg