### PR TITLE
fix: don't match embed hiding markup around x.com links

### DIFF
--- a/src/events/on_message/_advise.ts
+++ b/src/events/on_message/_advise.ts
@@ -8,15 +8,15 @@ import {
 } from 'discord.js';
 
 // Matches x.com links, but discards surrounding <> and () and trailing dots.
-const xUrlRegex = /(?:<|\()?https:\/\/x\.com\/([^>)\n .]+)(?:>|\))?/gm;
+const X_URL_REGEX = /(?:<|\()?https:\/\/x\.com\/([^>)\n .]+)(?:>|\))?/gm;
 
 export default async function mutate_content(message: Message) {
 	if (!message.channel.isTextBased() || message.channel.isDMBased()) return;
 
 	const links = message.content
-		.match(xUrlRegex)
+		.match(X_URL_REGEX)
 		?.map((link) =>
-			link.replace(xUrlRegex, 'https://xcancel.com/$1'),
+			link.replace(X_URL_REGEX, 'https://xcancel.com/$1'),
 		);
 
 	if (!links || links.length === 0) {

--- a/src/events/on_message/_advise.ts
+++ b/src/events/on_message/_advise.ts
@@ -6,16 +6,17 @@ import {
 	userMention,
 	type Message,
 } from 'discord.js';
-import urlRegex from 'url-regex';
+
+// Matches x.com links, but discards surrounding <> and () and trailing dots.
+const xUrlRegex = /(?:<|\()?https:\/\/x\.com\/([^>)\n .]+)(?:>|\))?/gm;
 
 export default async function mutate_content(message: Message) {
 	if (!message.channel.isTextBased() || message.channel.isDMBased()) return;
 
 	const links = message.content
-		.match(urlRegex())
-		?.filter((link) => link.startsWith('https://x.com'))
-		.map((link) =>
-			link.replace(/^https:\/\/x\.com/, 'https://xcancel.com'),
+		.match(xUrlRegex)
+		?.map((link) =>
+			link.replace(xUrlRegex, 'https://xcancel.com/$1'),
 		);
 
 	if (!links || links.length === 0) {

--- a/src/events/on_message/_advise.ts
+++ b/src/events/on_message/_advise.ts
@@ -15,9 +15,7 @@ export default async function mutate_content(message: Message) {
 
 	const links = message.content
 		.match(X_URL_REGEX)
-		?.map((link) =>
-			link.replace(X_URL_REGEX, 'https://xcancel.com/$1'),
-		);
+		?.map((link) => link.replace(X_URL_REGEX, 'https://xcancel.com/$1'));
 
 	if (!links || links.length === 0) {
 		return;


### PR DESCRIPTION
Currently Svelte Bot uses generic URL regex to match x.com links to replace with xcancel.com. However this matches trailing Embed Suppressing markup (ex. `<https://example.com/>`), causing this to happen:
```
@user I converted your `x.com` links to use `xcancel.com` so that server members won't require an account to view content and threads:
- https://xcancel.com/feross/status/12345>
```
Instead I've updated it to use a custom RegExp that doesn't match surrounding <> and () and trailing dots.
<img width="455" height="133" alt="image" src="https://github.com/user-attachments/assets/aaefbf63-2f11-4c70-9b63-8397021c99ba" />
