### PR TITLE
fix: adjust softban logic

### DIFF
--- a/src/utils/member_actions.ts
+++ b/src/utils/member_actions.ts
@@ -60,6 +60,11 @@ export async function kick(
 				reason,
 				deleteMessageSeconds: removeLastMessages,
 			});
+
+			// Artificial delay to ensure supposed message deletion
+			// background task completes before unbanning
+			await setTimeout(3_000);
+
 			await member.guild.members.unban(
 				member,
 				'Unbanning member with the intent to kick and delete messages.',


### PR DESCRIPTION
Follow up to:

- #79 
- #78 

Changes:

- Add artificial delay between ban and unban to ensure all messages are removed before unban.