### PR TITLE
fix: rate limit behaviour for multi-channel spam

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: Linting and Testing
 
 on:
     pull_request:
@@ -13,8 +13,8 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    lint:
-        name: Lint
+    prepare:
+        name: Prepare
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -33,7 +33,17 @@ jobs:
                   cache: pnpm
 
             - name: Install
-              run: pnpm install --frozen-lockfile
+              run: pnpm ci
 
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
             - name: Check
               run: pnpm check
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Run tests
+              run: pnpm test:ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    prepare:
-        name: Prepare
+    lint_and_test:
+        name: Lint and test
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -33,17 +33,10 @@ jobs:
                   cache: pnpm
 
             - name: Install
-              run: pnpm ci
+              run: pnpm install --frozen-lockfile
 
-    lint:
-        name: Lint
-        runs-on: ubuntu-latest
-        steps:
             - name: Check
               run: pnpm check
-    test:
-        name: Test
-        runs-on: ubuntu-latest
-        steps:
+
             - name: Run tests
               run: pnpm test:ci

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
 		"db:dev": "./pocketbase/dev.sh",
 		"start": "node src/index.ts",
 		"fix": "prettier --write . && biome check --write",
-		"check": "prettier --check . && tsc --noEmit && biome check && knip"
+		"check": "prettier --check . && tsc --noEmit && biome check && knip",
+		"test": "node --test --watch",
+		"test:ci": "node --test"
 	},
 	"license": "MIT",
 	"dependencies": {

--- a/src/events/on_message/_spam_filter.ts
+++ b/src/events/on_message/_spam_filter.ts
@@ -2,7 +2,7 @@ import { userMention, type Message } from 'discord.js';
 import { mod_forward, mod_log } from '../../utils/mod_logs.ts';
 import { has_any_role_or_id } from '../../utils/snowflake.ts';
 import { RateLimitStore } from '../../utils/ratelimit.ts';
-import { timeout, ban, kick } from '../../utils/member_actions.ts';
+import { ban, kick } from '../../utils/member_actions.ts';
 import { has_link, STOP } from './_common.ts';
 import {
 	SPAM_FILTER_MULTI_CHANNEL_ACTION,
@@ -28,18 +28,12 @@ export default async function spam_filter(message: Message) {
 		message.inGuild() &&
 		!message.thread &&
 		has_link(message) &&
-		single_channel_limit.is_limited(
-			message.author.id,
-			message.channelId,
-		);
+		single_channel_limit.is_limited(message.author.id, message.channelId);
 
 	const posts_many_messages_across_channels =
 		message.inGuild() &&
 		!message.thread &&
-		multi_channel_limit.is_limited(
-			message.author.id,
-			message.channelId,
-		);
+		multi_channel_limit.is_limited(message.author.id, message.channelId);
 
 	const posts_in_honeypot =
 		message.inGuild() &&
@@ -92,13 +86,10 @@ export default async function spam_filter(message: Message) {
 			]);
 		} else {
 			// Timeout
-			await Promise.allSettled([
-				timeout(member, 43_200_000, 'Multi-channel spam'),
-				mod_log(
-					message.client,
-					`User ${userMention(message.author.id)} was suspected of spamming and was timed out.`,
-				),
-			]);
+			mod_log(
+				message.client,
+				`User ${userMention(message.author.id)} was suspected of spamming.`,
+			);
 		}
 	}
 

--- a/src/events/on_message/_spam_filter.ts
+++ b/src/events/on_message/_spam_filter.ts
@@ -2,7 +2,7 @@ import { userMention, type Message } from 'discord.js';
 import { mod_forward, mod_log } from '../../utils/mod_logs.ts';
 import { has_any_role_or_id } from '../../utils/snowflake.ts';
 import { RateLimitStore } from '../../utils/ratelimit.ts';
-import { ban, kick } from '../../utils/member_actions.ts';
+import { ban, kick, timeout } from '../../utils/member_actions.ts';
 import { has_link, STOP } from './_common.ts';
 import {
 	SPAM_FILTER_MULTI_CHANNEL_ACTION,
@@ -23,73 +23,129 @@ function debug<T>(val: T): T {
 	return val;
 }
 
+const SpamAction = Object.freeze({
+	LOG: 'log',
+	TIMEOUT: 'timeout',
+	KICK: 'kick',
+	BAN: 'ban',
+});
+type SpamActionValues = (typeof SpamAction)[keyof typeof SpamAction]
+
+type SpamOptions = {
+	/**
+	 * Reason for kick/ban/timeout
+	 * e.g. `User was kicked for ${log_reason}`
+	 */
+	log_reason: string;
+};
+
+type SpamFilter = {
+	name: string;
+	condition: (message: Message) => boolean;
+	/** All actions log by default. */
+	action: SpamActionValues;
+	options?: SpamOptions;
+};
+const spam_filters: SpamFilter[] = [
+	{
+		name: 'Posts many links within a channel',
+		condition: (message) => {
+			return (
+				message.inGuild() &&
+				!message.thread &&
+				has_link(message) &&
+				single_channel_limit.is_limited(
+					message.author.id,
+					message.channelId,
+				)
+			);
+		},
+		action: 'ban',
+	},
+	{
+		name: 'Posts many messages across channels',
+		condition: (message) => {
+			return (
+				message.inGuild() &&
+				!message.thread &&
+				multi_channel_limit.is_limited(
+					message.author.id,
+					message.channelId,
+				)
+			);
+		},
+    get action(): SpamActionValues {
+      return SPAM_FILTER_MULTI_CHANNEL_ACTION ?? 'log'
+    },
+	},
+	{
+		name: 'Posts in honeypot',
+		condition: (message) => {
+			return (
+				message.inGuild() &&
+				message.channelId === HONEYPOT_CHANNEL &&
+				// Message by non-admin
+				!has_any_role_or_id(message.member, MODERATOR_IDS)
+			);
+		},
+		action: 'kick',
+		options: {
+			log_reason: 'posting in honeypot',
+		},
+	},
+];
+
 export default async function spam_filter(message: Message) {
-	const posts_many_links_within_a_channel =
-		message.inGuild() &&
-		!message.thread &&
-		has_link(message) &&
-		single_channel_limit.is_limited(message.author.id, message.channelId);
+	const spam_detected = spam_filters.find((filter) => {
+		return filter.condition(message);
+  });
 
-	const posts_many_messages_across_channels =
-		message.inGuild() &&
-		!message.thread &&
-		multi_channel_limit.is_limited(message.author.id, message.channelId);
-
-	const posts_in_honeypot =
-		message.inGuild() &&
-		message.channelId === HONEYPOT_CHANNEL &&
-		// Message by non-admin
-		!has_any_role_or_id(message.member, MODERATOR_IDS);
-
-	const is_likely_spam =
-		posts_many_links_within_a_channel ||
-		posts_many_messages_across_channels ||
-		posts_in_honeypot;
-
-	if (!is_likely_spam) return;
-
+  if (!spam_detected) return
 	console.log(`User ID: ${message.author.id} tripped spam filter`);
 
-	const member = debug(await message.guild.members.fetch(message.author.id));
+	const member = debug(await message.guild?.members.fetch(message.author.id));
 	const is_threadlord = has_any_role_or_id(member, THREAD_ADMIN_IDS);
 
 	if (DEV_MODE) {
 		await message.reply('Oi, stop spamming you troglodyte.');
 		// Unlikely to be spam from trusted members
-	} else if (!debug(is_threadlord)) {
+	} else if (!debug(is_threadlord) && spam_detected && member) {
+		// Forward last message
 		await mod_forward(message);
+		const log_reason = spam_detected.options?.log_reason;
 
-		if (
-			posts_many_links_within_a_channel ||
-			(posts_many_messages_across_channels &&
-				SPAM_FILTER_MULTI_CHANNEL_ACTION === 'ban')
-		) {
-			// Ban
-			await Promise.allSettled([
-				ban(member, 3),
-				member.send(
-					'You were banned from the Svelte discord server for spamming. If you believe this was a mistake you can appeal the ban at <https://github.com/pngwn/svelte-bot/issues/38>',
-				),
-				mod_log(
-					message.client,
-					`User ${userMention(message.author.id)} was suspected of spamming and was banned.`,
-				),
-			]);
-		} else if (posts_in_honeypot) {
-			// Kick
-			await Promise.allSettled([
-				kick(member, 'Posting in honeypot'),
-				mod_log(
-					message.client,
-					`User ${userMention(message.author.id)} was kicked for posting in honeypot.`,
-				),
-			]);
-		} else {
-			// Timeout
-			mod_log(
-				message.client,
-				`User ${userMention(message.author.id)} was suspected of spamming.`,
-			);
+		switch (spam_detected.action) {
+			// TODO timeout case
+			case SpamAction.BAN:
+				await Promise.allSettled([
+					ban(member, 3),
+					member.send(
+						'You were banned from the Svelte discord server for spamming. If you believe this was a mistake you can appeal the ban at <https://github.com/pngwn/svelte-bot/issues/38>',
+					),
+					mod_log(
+						message.client,
+						`User ${userMention(message.author.id)} was suspected of spamming and was banned.`,
+					),
+				]);
+				break;
+			case SpamAction.KICK:
+				await Promise.allSettled([
+					kick(member, log_reason),
+					mod_log(
+						message.client,
+						`User ${userMention(message.author.id)} was kicked${log_reason ? ` for ${log_reason}` : ''}.`,
+					),
+				]);
+        break;
+      case SpamAction.TIMEOUT:
+        await Promise.allSettled([
+          timeout(member, { reason: log_reason }),
+          mod_log(
+						message.client,
+						`User ${userMention(message.author.id)} was timed out${log_reason ? ` for ${log_reason}` : ''}.`,
+					),
+        ])
+        break;
 		}
 	}
 

--- a/src/events/on_message/_spam_filter.ts
+++ b/src/events/on_message/_spam_filter.ts
@@ -29,7 +29,7 @@ const SpamAction = Object.freeze({
 	KICK: 'kick',
 	BAN: 'ban',
 });
-type SpamActionValues = (typeof SpamAction)[keyof typeof SpamAction]
+type SpamActionValues = (typeof SpamAction)[keyof typeof SpamAction];
 
 type SpamOptions = {
 	/**
@@ -74,9 +74,12 @@ const spam_filters: SpamFilter[] = [
 				)
 			);
 		},
-    get action(): SpamActionValues {
-      return SPAM_FILTER_MULTI_CHANNEL_ACTION ?? 'log'
-    },
+		get action(): SpamActionValues {
+			return SPAM_FILTER_MULTI_CHANNEL_ACTION ?? 'log';
+		},
+		options: {
+			log_reason: 'posting messages across many channels',
+		},
 	},
 	{
 		name: 'Posts in honeypot',
@@ -98,9 +101,9 @@ const spam_filters: SpamFilter[] = [
 export default async function spam_filter(message: Message) {
 	const spam_detected = spam_filters.find((filter) => {
 		return filter.condition(message);
-  });
+	});
 
-  if (!spam_detected) return
+	if (!spam_detected) return;
 	console.log(`User ID: ${message.author.id} tripped spam filter`);
 
 	const member = debug(await message.guild?.members.fetch(message.author.id));
@@ -136,16 +139,22 @@ export default async function spam_filter(message: Message) {
 						`User ${userMention(message.author.id)} was kicked${log_reason ? ` for ${log_reason}` : ''}.`,
 					),
 				]);
-        break;
-      case SpamAction.TIMEOUT:
-        await Promise.allSettled([
-          timeout(member, { reason: log_reason }),
-          mod_log(
+				break;
+			case SpamAction.TIMEOUT:
+				await Promise.allSettled([
+					timeout(member, { reason: log_reason }),
+					mod_log(
 						message.client,
 						`User ${userMention(message.author.id)} was timed out${log_reason ? ` for ${log_reason}` : ''}.`,
 					),
-        ])
-        break;
+				]);
+				break;
+			default:
+				await mod_log(
+					message.client,
+					`Log note for user ${userMention(message.author.id)}: ${log_reason ?? 'no reason provided'}.`,
+				);
+				break;
 		}
 	}
 

--- a/src/events/on_message/_spam_filter.ts
+++ b/src/events/on_message/_spam_filter.ts
@@ -31,7 +31,6 @@ export default async function spam_filter(message: Message) {
 		single_channel_limit.is_limited(
 			message.author.id,
 			message.channelId,
-			true,
 		);
 
 	const posts_many_messages_across_channels =
@@ -40,7 +39,6 @@ export default async function spam_filter(message: Message) {
 		multi_channel_limit.is_limited(
 			message.author.id,
 			message.channelId,
-			true,
 		);
 
 	const posts_in_honeypot =

--- a/src/utils/member_actions.test.ts
+++ b/src/utils/member_actions.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { timeout } from './member_actions.ts'
+
+describe('timeout', () => {
+  it('times out member', () => {
+    const member = {
+      timeout: mock.fn()
+    }
+
+    // @ts-ignore
+    timeout(member)
+    assert.deepStrictEqual(member.timeout.mock.calls[0].arguments, [43_200_000, 'Bot action'])
+  })
+
+  it('times out member with custom reason', () => {
+    const member = {
+      timeout: mock.fn()
+    }
+
+    // @ts-ignore
+    timeout(member, { reason: 'just because'})
+    assert.deepStrictEqual(member.timeout.mock.calls[0].arguments, [43_200_000, 'just because'])
+  })
+})

--- a/src/utils/member_actions.test.ts
+++ b/src/utils/member_actions.test.ts
@@ -1,25 +1,31 @@
-import { describe, it, mock } from 'node:test'
-import assert from 'node:assert/strict'
-import { timeout } from './member_actions.ts'
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { timeout } from './member_actions.ts';
 
 describe('timeout', () => {
-  it('times out member', () => {
-    const member = {
-      timeout: mock.fn()
-    }
+	it('times out member', () => {
+		const member = {
+			timeout: mock.fn(),
+		};
 
-    // @ts-ignore
-    timeout(member)
-    assert.deepStrictEqual(member.timeout.mock.calls[0].arguments, [43_200_000, 'Bot action'])
-  })
+		// @ts-expect-error
+		timeout(member);
+		assert.deepStrictEqual(member.timeout.mock.calls[0].arguments, [
+			43_200_000,
+			'Bot action',
+		]);
+	});
 
-  it('times out member with custom reason', () => {
-    const member = {
-      timeout: mock.fn()
-    }
+	it('times out member with custom reason', () => {
+		const member = {
+			timeout: mock.fn(),
+		};
 
-    // @ts-ignore
-    timeout(member, { reason: 'just because'})
-    assert.deepStrictEqual(member.timeout.mock.calls[0].arguments, [43_200_000, 'just because'])
-  })
-})
+		// @ts-expect-error
+		timeout(member, { reason: 'just because' });
+		assert.deepStrictEqual(member.timeout.mock.calls[0].arguments, [
+			43_200_000,
+			'just because',
+		]);
+	});
+});

--- a/src/utils/member_actions.ts
+++ b/src/utils/member_actions.ts
@@ -4,23 +4,33 @@ import { setTimeout } from 'node:timers/promises';
 /** 24 hours in seconds. */
 const TWENTY_FOUR_HOURS = 86_400;
 
+/** 12 hours in ms */
+const TWELVE_HOURS_MS = 43_200_000;
+
 /** Two hours in seconds */
 const TWO_HOURS = 7_200;
+
+type TimeoutOptions = {
+	timeout_length?: number;
+	reason?: string;
+	retries?: number;
+};
 
 /**
  * Time out member.
  * @param member
- * @param timeout_length Timeout period in ms
- * @param reason Timeout reason
- * @param retries Timeout action retries
+ * @param options
+ * @property options.timeout_length Timeout period in ms
+ * @property options.reason Timeout reason
+ * @property options.retries Timeout action retries
  */
-export async function timeout(
-	member: GuildMember,
-	timeout_length = 43_200_000, // 12 hours
-	reason = 'Bot action',
-	/** @default 3 */
-	retries = 3,
-) {
+export async function timeout(member: GuildMember, options?: TimeoutOptions) {
+	const { reason, retries, timeout_length } = Object.assign({}, {
+		timeout_length: TWELVE_HOURS_MS,
+		reason: 'Bot action',
+		retries: 3,
+	}, options);
+
 	let retries_remaining = retries;
 
 	while (--retries_remaining && member.timeout) {

--- a/src/utils/member_actions.ts
+++ b/src/utils/member_actions.ts
@@ -25,11 +25,15 @@ type TimeoutOptions = {
  * @property options.retries Timeout action retries
  */
 export async function timeout(member: GuildMember, options?: TimeoutOptions) {
-	const { reason, retries, timeout_length } = Object.assign({}, {
-		timeout_length: TWELVE_HOURS_MS,
-		reason: 'Bot action',
-		retries: 3,
-	}, options);
+	const { reason, retries, timeout_length } = Object.assign(
+		{},
+		{
+			timeout_length: TWELVE_HOURS_MS,
+			reason: 'Bot action',
+			retries: 3,
+		},
+		options,
+	);
 
 	let retries_remaining = retries;
 

--- a/src/utils/ratelimit.test.ts
+++ b/src/utils/ratelimit.test.ts
@@ -1,39 +1,39 @@
-import { afterEach, describe, it } from 'node:test'
-import assert from 'node:assert'
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert';
 import { RateLimitStore } from './ratelimit.ts';
 
 describe('RateLimitStore', () => {
-  afterEach(() => {
-    RateLimitStore.clear_timers()
-  })
+	afterEach(() => {
+		RateLimitStore.clear_timers();
+	});
 
-  it('detects single channel spam', () => {
-    // 3 messages within a 5 second period
-    const single_channel_limit = new RateLimitStore(3, 5_000, 1);
-    single_channel_limit.is_limited('abc', 'one')
-    single_channel_limit.is_limited('abc', 'one')
-    single_channel_limit.is_limited('abc', 'one')
+	it('detects single channel spam', () => {
+		// 3 messages within a 5 second period
+		const single_channel_limit = new RateLimitStore(3, 5_000, 1);
+		single_channel_limit.is_limited('abc', 'one');
+		single_channel_limit.is_limited('abc', 'one');
+		single_channel_limit.is_limited('abc', 'one');
 
-    assert.strictEqual(single_channel_limit.is_limited('abc', 'one'), true)
-  })
+		assert.strictEqual(single_channel_limit.is_limited('abc', 'one'), true);
+	});
 
-  it('detects multi channel spam', () => {
-    // 3 messages across 3 channels within a 10 second period
-    const multi_channel_limit = new RateLimitStore(3, 10_000, 3);
-    multi_channel_limit.is_limited('abc', 'one')
-    multi_channel_limit.is_limited('abc', 'two')
-    multi_channel_limit.is_limited('abc', 'three')
+	it('detects multi channel spam', () => {
+		// 3 messages across 3 channels within a 10 second period
+		const multi_channel_limit = new RateLimitStore(3, 10_000, 3);
+		multi_channel_limit.is_limited('abc', 'one');
+		multi_channel_limit.is_limited('abc', 'two');
+		multi_channel_limit.is_limited('abc', 'three');
 
-    assert.strictEqual(multi_channel_limit.is_limited('abc', 'four'), true)
-  })
+		assert.strictEqual(multi_channel_limit.is_limited('abc', 'four'), true);
+	});
 
-  it('does not interpret single channel spam as multi channel spam', () => {
-    // 3 messages across 3 channels within a 10 second period
-    const multi_channel_limit = new RateLimitStore(3, 10_000, 3);
-    multi_channel_limit.is_limited('abc', 'one')
-    multi_channel_limit.is_limited('abc', 'one')
-    multi_channel_limit.is_limited('abc', 'one')
+	it('does not interpret single channel spam as multi channel spam', () => {
+		// 3 messages across 3 channels within a 10 second period
+		const multi_channel_limit = new RateLimitStore(3, 10_000, 3);
+		multi_channel_limit.is_limited('abc', 'one');
+		multi_channel_limit.is_limited('abc', 'one');
+		multi_channel_limit.is_limited('abc', 'one');
 
-    assert.strictEqual(multi_channel_limit.is_limited('abc', 'one'), false)
-  })
-})
+		assert.strictEqual(multi_channel_limit.is_limited('abc', 'one'), false);
+	});
+});

--- a/src/utils/ratelimit.test.ts
+++ b/src/utils/ratelimit.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import { RateLimitStore } from './ratelimit.ts';
+
+describe('RateLimitStore', () => {
+  afterEach(() => {
+    RateLimitStore.clear_timers()
+  })
+
+  it('detects single channel spam', () => {
+    // 3 messages within a 5 second period
+    const single_channel_limit = new RateLimitStore(3, 5_000, 1);
+    single_channel_limit.is_limited('abc', 'one')
+    single_channel_limit.is_limited('abc', 'one')
+    single_channel_limit.is_limited('abc', 'one')
+
+    assert.strictEqual(single_channel_limit.is_limited('abc', 'one'), true)
+  })
+
+  it('detects multi channel spam', () => {
+    // 3 messages across 3 channels within a 10 second period
+    const multi_channel_limit = new RateLimitStore(3, 10_000, 3);
+    multi_channel_limit.is_limited('abc', 'one')
+    multi_channel_limit.is_limited('abc', 'two')
+    multi_channel_limit.is_limited('abc', 'three')
+
+    assert.strictEqual(multi_channel_limit.is_limited('abc', 'four'), true)
+  })
+
+  it('does not interpret single channel spam as multi channel spam', () => {
+    // 3 messages across 3 channels within a 10 second period
+    const multi_channel_limit = new RateLimitStore(3, 10_000, 3);
+    multi_channel_limit.is_limited('abc', 'one')
+    multi_channel_limit.is_limited('abc', 'one')
+    multi_channel_limit.is_limited('abc', 'one')
+
+    assert.strictEqual(multi_channel_limit.is_limited('abc', 'one'), false)
+  })
+})

--- a/src/utils/ratelimit.ts
+++ b/src/utils/ratelimit.ts
@@ -10,7 +10,7 @@ export class RateLimitStore {
 	private time_period;
 	private count;
 
-	public static timers: NodeJS.Timeout[] = [];
+	public static timers = new Set<NodeJS.Timeout>();
 
 	constructor(count: number, time_period: number, unique_channels: number) {
 		this.count = count;
@@ -48,12 +48,15 @@ export class RateLimitStore {
 		return true;
 	}
 
-	private create_new_bucket(key: string) {
-		const timer = setTimeout(() => {
-			this.available_uses.delete(key);
+  private create_new_bucket(key: string) {
+    let timer: NodeJS.Timeout
+
+		timer = setTimeout(() => {
+      this.available_uses.delete(key);
+      RateLimitStore.timers.delete(timer)
 		}, this.time_period);
 
-		RateLimitStore.timers.push(timer);
+		RateLimitStore.timers.add(timer);
 		return this.count;
 	}
 }

--- a/src/utils/ratelimit.ts
+++ b/src/utils/ratelimit.ts
@@ -8,22 +8,30 @@ export class RateLimitStore {
 	/** How many unique channels to track */
 	private unique_channels;
 	private time_period;
-	private count;
+  private count;
+
+  public static timers: NodeJS.Timeout[] = []
 
 	constructor(count: number, time_period: number, unique_channels: number) {
 		this.count = count;
 		this.time_period = time_period;
 		this.unique_channels = unique_channels;
-	}
+  }
+
+  public static clear_timers() {
+    RateLimitStore.timers.forEach(timer => {
+      clearTimeout(timer)
+    })
+  }
 
 	/**
 	 * Check whether provide key/user reaches rate limit.
 	 *
 	 * @param key Reference key in available use store; usually `author.id`
 	 * @param channelId Unique channel ID where message was sent and tracked for rate limit.
-	 * @param consume If `true`, decrement remaining limit for `key` user.
+	 * @returns `true` when rate limited, otherwise `false`.
 	 */
-	public is_limited(key: string, channelId: string, consume = false) {
+	public is_limited(key: string, channelId: string) {
 		const limit_record = this.available_uses.get(key);
 
 		const available_uses =
@@ -31,21 +39,21 @@ export class RateLimitStore {
 		const channels = limit_record?.channel_ids ?? new Set();
 
 		if (available_uses > 0 || channels.size < this.unique_channels) {
-			if (consume) {
-				this.available_uses.set(key, {
-					limit: available_uses - 1,
-					channel_ids: channels.add(channelId),
-				});
-			}
+			this.available_uses.set(key, {
+				limit: available_uses - 1,
+				channel_ids: channels.add(channelId),
+			});
 			return false;
 		}
 		return true;
 	}
 
 	private create_new_bucket(key: string) {
-		setTimeout(() => {
+		const timer = setTimeout(() => {
 			this.available_uses.delete(key);
-		}, this.time_period);
+    }, this.time_period)
+
+		RateLimitStore.timers.push(timer)
 		return this.count;
 	}
 }

--- a/src/utils/ratelimit.ts
+++ b/src/utils/ratelimit.ts
@@ -30,7 +30,7 @@ export class RateLimitStore {
 			limit_record?.limit ?? this.create_new_bucket(key);
 		const channels = limit_record?.channel_ids ?? new Set();
 
-		if (available_uses > 0 && channels.size < this.unique_channels) {
+		if (available_uses > 0 || channels.size < this.unique_channels) {
 			if (consume) {
 				this.available_uses.set(key, {
 					limit: available_uses - 1,

--- a/src/utils/ratelimit.ts
+++ b/src/utils/ratelimit.ts
@@ -48,12 +48,12 @@ export class RateLimitStore {
 		return true;
 	}
 
-  private create_new_bucket(key: string) {
-    let timer: NodeJS.Timeout
+	private create_new_bucket(key: string) {
+		let timer: NodeJS.Timeout;
 
 		timer = setTimeout(() => {
-      this.available_uses.delete(key);
-      RateLimitStore.timers.delete(timer)
+			this.available_uses.delete(key);
+			RateLimitStore.timers.delete(timer);
 		}, this.time_period);
 
 		RateLimitStore.timers.add(timer);

--- a/src/utils/ratelimit.ts
+++ b/src/utils/ratelimit.ts
@@ -8,21 +8,21 @@ export class RateLimitStore {
 	/** How many unique channels to track */
 	private unique_channels;
 	private time_period;
-  private count;
+	private count;
 
-  public static timers: NodeJS.Timeout[] = []
+	public static timers: NodeJS.Timeout[] = [];
 
 	constructor(count: number, time_period: number, unique_channels: number) {
 		this.count = count;
 		this.time_period = time_period;
 		this.unique_channels = unique_channels;
-  }
+	}
 
-  public static clear_timers() {
-    RateLimitStore.timers.forEach(timer => {
-      clearTimeout(timer)
-    })
-  }
+	public static clear_timers() {
+		for (const timer of RateLimitStore.timers) {
+			clearTimeout(timer);
+		}
+	}
 
 	/**
 	 * Check whether provide key/user reaches rate limit.
@@ -51,9 +51,9 @@ export class RateLimitStore {
 	private create_new_bucket(key: string) {
 		const timer = setTimeout(() => {
 			this.available_uses.delete(key);
-    }, this.time_period)
+		}, this.time_period);
 
-		RateLimitStore.timers.push(timer)
+		RateLimitStore.timers.push(timer);
 		return this.count;
 	}
 }


### PR DESCRIPTION
## Problem

- members rapidly posting 3+ messages within a 10-second period in a single channel were incorrectly flagged as multi-channel spam attempts because the rate limit on the messages alone would short-circuit the logic and not check for multi-channel spam.
   https://github.com/sveltejs/discord-bot/blob/3cf765e2dd4217d1ced99f1fbdce24fb428ebfae/src/utils/ratelimit.ts#L33-L41
- Those members were timed out as a result.
   https://github.com/sveltejs/discord-bot/blob/3cf765e2dd4217d1ced99f1fbdce24fb428ebfae/src/events/on_message/_spam_filter.ts#L96-L103

## Solution

- adjust rate limit logic to correctly detect multi-channel usage
- remove timeout for now, so we can opt back in via an environment variable. For now, mutli-channel-spam is logged to moderators.

## Todos

- [x] Fix multi-channel spam rate limit detection
- [x] Remove timeout on multi-channel spam
- [x] Add unit test
- [x] Add config flag to timeout on multi channel spam